### PR TITLE
DEVOPS-895 - Fix NVM in our Github Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
+          node-version-file: ".nvmrc"
           registry-url: https://npm.pkg.github.com/
           scope: "@polarislabs"
-          node-version-file: ".nvmrc"
       - name: Install dependencies
         run: npm ci
         env:

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
+          node-version-file: ".nvmrc"
           registry-url: https://npm.pkg.github.com/
           scope: "@polarislabs"
-          node-version-file: ".nvmrc"
       - name: Install dependencies
         run: npm ci
         env:


### PR DESCRIPTION
Update `setup-node` to v3.
Use new `node-version-file` option to read the version from the `.nvmrc`.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖